### PR TITLE
Specify AllDataProjection.getRowProperties and MultiValueProjection.g…

### DIFF
--- a/src/main/groovy/org/transmartproject/core/dataquery/highdim/projections/AllDataProjection.groovy
+++ b/src/main/groovy/org/transmartproject/core/dataquery/highdim/projections/AllDataProjection.groovy
@@ -5,7 +5,8 @@ public interface AllDataProjection extends Projection<Map<String, Object>>, Mult
 
     /**
      * Returns a map with the names and types of the datatype specific properties that
-     * are available on the rows belonging to this datatype.
+     * are available on the rows belonging to this datatype. The returned map has a
+     * stable and meaningful iteration order.
      */
     public Map<String, Class> getRowProperties()
 

--- a/src/main/groovy/org/transmartproject/core/dataquery/highdim/projections/MultiValueProjection.groovy
+++ b/src/main/groovy/org/transmartproject/core/dataquery/highdim/projections/MultiValueProjection.groovy
@@ -5,7 +5,7 @@ public interface MultiValueProjection {
 
     /**
      * Returns a map with the keys/properties and types that are available in the object returned by
-     * queries using this projection.
+     * queries using this projection. The returned map has a stable and meaningful iteration order.
      */
     public Map<String, Class> getDataProperties()
 


### PR DESCRIPTION
…etDataProperties to have a stable iteration order

Goes with accompanying PR in core db.
