### PR TITLE
Retrieve assay columns in the correct order.

### DIFF
--- a/src/main/groovy/org/transmartproject/core/dataquery/highdim/HighDimensionDataTypeResource.groovy
+++ b/src/main/groovy/org/transmartproject/core/dataquery/highdim/HighDimensionDataTypeResource.groovy
@@ -63,6 +63,22 @@ interface HighDimensionDataTypeResource<R extends DataRow<AssayColumn, ? /* depe
                                                  Projection projection)
 
     /**
+     * Retrieves assay column information from the database.
+     * The result is a list of assays.
+     * The list is identical to the <code>indicesList</code> in the <code>TabularResult</code>
+     * returned by {@link #retrieveData}.
+     *
+     * An {@link EmptySetException} exception is thrown if and only if
+     * the assay constraints do not satisfy any assay.
+     *
+     * @param assayConstraints list of constraints that filter the columns/
+     * assays that are to be included in the result set
+     * @return the assays matching the assay constraints.
+     * @throws EmptySetException iff no assays can be found
+     */
+    List<AssayColumn> retrieveAssays(List<AssayConstraint> assayConstraints)
+
+    /**
      * The list of {@link AssayConstraint} types supported by this data type,
      * identified by their name.
      * Only constraints of this type can by passed to this resource's


### PR DESCRIPTION
A new function has been added to high dimensional
data types that retrieves assay columns in the correct
order.

Related to https://github.com/thehyve/naa-transmart-core-db/pull/13
in transmart-core-db.
